### PR TITLE
fix POJ 3974 std

### DIFF
--- a/配套光盘/例题/0x10 基本数据结构/0x14 Hash/Palindrome/POJ3974 Palindrome.cpp
+++ b/配套光盘/例题/0x10 基本数据结构/0x14 Hash/Palindrome/POJ3974 Palindrome.cpp
@@ -28,14 +28,14 @@ int main() {
 		for (int i = 1; i <= len; i++) f1[i] = f1[i - 1] * P + s[i];
 		for (int i = len; i; i--) f2[i] = f2[i + 1] * P + s[i];
 		for (int i = 1; i <= len; i++) {
-			int l = 1, r = min(i - 1, len - i);
+			int l = 0, r = min(i - 1, len - i);
 			while (l < r) {
 				int mid = (l + r + 1) >> 1;
 				if (H1(i - mid, i - 1) == H2(i + 1, i + mid)) l = mid;
 				else r = mid - 1;
 			}
 			ans = max(l * 2 + 1, ans);
-			l = 1, r = min(i - 1, len - i + 1);
+			l = 0, r = min(i - 1, len - i + 1);
 			while (l < r) {
 				int mid = (l + r + 1) >> 1;
 				if (H1(i - mid, i - 1) == H2(i, i + mid - 1)) l = mid;


### PR DESCRIPTION
原代码在输入数据无长度大于等于3的回文子串时（例如`abcd` `aabb`）会输出3（二分结束后`l = 1`）

不过原代码也能在POJ上通过……估计数据没有这种情况