### PR TITLE
Update BZOJ1218 激光炸弹.cpp

### DIFF
--- a/配套光盘/例题/0x00 基本算法/0x03 前缀和与差分/激光炸弹/BZOJ1218 激光炸弹.cpp
+++ b/配套光盘/例题/0x00 基本算法/0x03 前缀和与差分/激光炸弹/BZOJ1218 激光炸弹.cpp
@@ -13,7 +13,7 @@ int main() {
 	while (n--) {
 		int x, y, z;
 		scanf("%d %d %d", &x, &y, &z);
-		s[x][y] = z;
+		s[x][y] += z;
 	}
 	for (int i = 0; i <= 5000; i++)
 		for (int j = 0; j <= 5000; j++)


### PR DESCRIPTION
题目非常明显的表示了“不同目标可能在同一位置。”，因此s[x][y] = z会导致同一位置的目标被忽略